### PR TITLE
Toc finsih buttion pdf flow updated

### DIFF
--- a/library/ws-widget/collection/src/lib/player-pdf/player-pdf.component.ts
+++ b/library/ws-widget/collection/src/lib/player-pdf/player-pdf.component.ts
@@ -220,6 +220,15 @@ export class PlayerPdfComponent extends WidgetBaseComponent
     if (!this.widgetData.disableTelemetry) {
       this.eventDispatcher(WsEvents.EnumTelemetrySubType.StateChange)
     }
+    if (pageNum === this.totalPages) {
+      if (this.identifier) {
+        const pageNumStr = this.currentPage.value.toString()
+        if (!this.current.includes(pageNumStr)) {
+          this.current.push(pageNumStr)
+        }
+        this.fireRealTimeProgress(this.identifier)
+      }
+    }
   }
   raiseTelemetry(action: string) {
     if (this.identifier) {

--- a/project/ws/viewer/src/lib/viewer-util.service.ts
+++ b/project/ws/viewer/src/lib/viewer-util.service.ts
@@ -79,7 +79,8 @@ export class ViewerUtilService {
         mimeType === NsContent.EMimeTypes.M3U8 ||
         mimeType === NsContent.EMimeTypes.MP3 ||
         mimeType === NsContent.EMimeTypes.M4A ||
-        mimeType === NsContent.EMimeTypes.SURVEY
+        mimeType === NsContent.EMimeTypes.SURVEY ||
+        mimeType === NsContent.EMimeTypes.PDF
       ) {
         // if percentage is less than 5% then make status started
         if (Math.ceil(percentage) <= 5) {


### PR DESCRIPTION
If pdf is last resource, progress update api was not being called on the last page (was happening on next click) so have added the condition. So that on finish click, progress read api gives the status.